### PR TITLE
Allow to customize nginx http access rules

### DIFF
--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -2,3 +2,8 @@ FROM nginx
 MAINTAINER Camptocamp
 
 COPY etc/nginx.conf /etc/nginx/nginx.conf
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/9.0/docker-entrypoint.sh
+++ b/9.0/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+echo "${NGX_HTTP_ACCESS}" > /etc/nginx/http-access.conf
+
+exec "$@"

--- a/9.0/etc/nginx.conf
+++ b/9.0/etc/nginx.conf
@@ -12,6 +12,7 @@ events {
 
 http {
   include /etc/nginx/mime.types;
+  include /etc/nginx/http-access.conf;
   default_type  application/octet-stream;
 
   sendfile on;


### PR DESCRIPTION
The rules are declared using the environment variable "NGX_HTTP_ACCESS"
with multilines.

Example in docker-compose.yml:

```yaml
  nginx:
    image: camptocamp/odoo-nginx:9.0
    depends_on:
      - odoo
    environment:
      NGX_HTTP_ACCESS: |
          allow 192.168.1.1;
          allow 172.21.0.1;
          deny all;
```