### PR TITLE
Fix buffer settings

### DIFF
--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -69,7 +69,7 @@ http {
   proxy_buffer_size       1k;
   proxy_busy_buffers_size 8k;
   proxy_max_temp_file_size  2048m;
-  proxy_temp_file_write_size  32k;
+  proxy_temp_file_write_size  64k;
 
   proxy_cache_path /tmp/nginx levels=1:2 keys_zone=one:10m inactive=60m;
 
@@ -103,6 +103,7 @@ http {
       add_header X-Static no;
       proxy_buffering off;
       proxy_buffer_size 64k;
+      proxy_busy_buffers_size 64k;
       proxy_intercept_errors on;
     }
 


### PR DESCRIPTION
Nginx config parser cannot see variables context,
so we need to specify coherent values even if they are not used