### PR TITLE
Fix caching of requests with Set-Cookie

### DIFF
--- a/9.0/conf.d/proxy_headers.toml
+++ b/9.0/conf.d/proxy_headers.toml
@@ -1,0 +1,12 @@
+[template]
+
+# The name of the template that will be used to render the application's configuration file
+# Confd will look in `/etc/conf.d/templates` for these files by default
+src = "proxy_headers.conf.tmpl"
+
+# The location to place the rendered configuration file
+dest = "/etc/nginx/proxy_headers.conf"
+
+# File ownership and mode information
+owner = "root"
+mode = "0644"

--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -73,12 +73,8 @@ http {
 
   proxy_cache_path /tmp/nginx levels=1:2 keys_zone=one:10m inactive=60m;
 
-  proxy_set_header         Host $http_host;
-  proxy_set_header         X-Real-IP $remote_addr;
-  proxy_set_header         X-Forward-For $proxy_add_x_forwarded_for;
-  # when redirecting to https:
-  # proxy_set_header         X-Forwarded-Proto https;
-  proxy_set_header         X-Forwarded-Host $http_host;
+  include /etc/nginx/proxy_headers.conf;
+
   proxy_headers_hash_bucket_size 64;
 
   # List of application servers
@@ -141,6 +137,15 @@ http {
 
       proxy_cache_bypass $http_cache_control;
       add_header X-Cache-Status $upstream_cache_status;
+
+      # Forward If-None-Match (which contains the ETag), so Odoo can decide
+      # to return a 304 instead of the content. Nginx would have returned a 304
+      # anyway, but we spare some traffic between odoo and nginx.
+      proxy_set_header If-None-Match $http_if_none_match; 
+
+      # there is no inheritance of proxy_set_header, as soon as we define one at a level,
+      # we need to redefine all
+      include /etc/nginx/proxy_headers.conf;
       
       proxy_pass http://{{ $odoo_host }}:8069;
     }

--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -132,7 +132,13 @@ http {
       proxy_cache_lock on;
 
       proxy_buffering on;
+
+      # remove the cookie from the cached payload
+      proxy_hide_header Set-Cookie;
+      # ensure that caching is done by ignoring set-cookie
       proxy_ignore_headers Set-Cookie;
+      proxy_set_header Cookie "";
+
       proxy_cache_bypass $http_cache_control;
       add_header X-Cache-Status $upstream_cache_status;
       

--- a/9.0/templates/proxy_headers.conf.tmpl
+++ b/9.0/templates/proxy_headers.conf.tmpl
@@ -1,0 +1,4 @@
+proxy_set_header         Host $http_host;
+proxy_set_header         X-Real-IP $remote_addr;
+proxy_set_header         X-Forward-For $proxy_add_x_forwarded_for;
+proxy_set_header         X-Forwarded-Host $http_host;


### PR DESCRIPTION
Odoo publishes static files with a Set-Cookie header that contains the
session of the user. The cache entry was ignoring the Set-Cookie header for
the key of the entry, but was returning it in the cached response. Which
means that the first user to login would fill the cache with their cookie.
The subsequent users to reach the nginx cache (users having a browser cache
should not be affected) would receive a request containing a Set-Cookie
header of the first user → the browser obtains the session_id of another
user.

The reason was that proxy_ignore_headers removes the Set-Cookie from the cache entry key, but
not from the cached respons
Adding proxy_hide_header hides the header in the cached response.

Alongside this change, 'proxy_set_header Cookie ""' prevents to pass any
cookie to odoo on static files.

----

Pass If-None-Match header to odoo

When Odoo receives it, it'll compare the ETag of the new response and if
it's the same, it'll return a 304 HTTP code instead of the content. Nginx
does the same in any case but it spares some data between odoo and nginx.