### PR TITLE
Fix cache issues by removing some caching

### DIFF
--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -116,10 +116,6 @@ http {
       try_files =404 @cached;
     }
 
-    location /website/translations {
-      try_files =404 @cached;
-    }
-
     location @cached {
       proxy_cache one;
       proxy_cache_valid 60m;

--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -110,7 +110,9 @@ http {
       try_files =404 @cached;
     }
 
-    location /web/content {
+    # warning: /web/content reads ir.attachment, it would not be safe to
+    # cache other files than .js / .css which can depend on users rights
+    location ~* ^/web/content/.+\.(js|css)$ {
       try_files =404 @cached;
     }
 


### PR DESCRIPTION
* Cache only .js and .css files on /web/content

  The .js and .css files are the generated "reduced" files, they are not dependent of any session.
  However, the other files on /web/content can be any ir.attachment, so the
  controller must be aware of the session, ir.rules have to be be applied.

* Remove /website/translations from cache

  This is a route with auth="public" in odoo, which means odoo excepts a
  session_id and we don't want to share session ids in a cache. It was
  spawning Session Expired errors on the requests hitting this path.