### PR TITLE
Change log keys to match apache's keys

### DIFF
--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -20,21 +20,21 @@ http {
   server_tokens off;
 
   access_log off;
-  log_format json_combined escape=json '{ "time_local": "$time_iso8601", '
-   '"remote_addr": "$remote_addr", '
-   '"remote_user": "$remote_user", '
-   '"request_method": "$request_method", '
-   '"request_uri": "$request_uri", '
-   '"server_protocol": "$server_protocol", '
-   '"status": "$status", '
-   '"body_bytes_sent": "$body_bytes_sent", '
-   '"rt": "$request_time", '
-   '"uct": "$upstream_connect_time", '
-   '"uht": "$upstream_header_time", '
-   '"urt": "$upstream_response_time", '
+  log_format json_combined escape=json '{ "timestamp": "$time_iso8601", '
+   '"clientip": "$remote_addr", '
+   '"host": "$host", '
+   '"auth": "$remote_user", '
+   '"verb": "$request_method", '
+   '"request": "$request_uri", '
+   '"httpversion": "$server_protocol", '
+   '"response": "$status", '
+   '"bytes": "$body_bytes_sent", '
+   '"time_request": "$request_time", '
+   '"time_backend_connect": "$upstream_connect_time", '
+   '"time_backend_response": "$upstream_response_time", '
    '"cache": "$upstream_cache_status", '
-   '"http_referrer": "$http_referer", '
-   '"http_user_agent": "$http_user_agent" }';
+   '"referrer": "$http_referer", '
+   '"agent": "$http_user_agent" }';
 
   types_hash_max_size 1024;
   types_hash_bucket_size 512;


### PR DESCRIPTION
The goal is to have the same keys for Apache and Nginx so we can have
similar logstash configuration and kibana boards.
All the keys share the Apache's ones but the "time_*" which are the same
than the HAproxy's ones, because we don't have them in Apache.

Examples:

```
{ "timestamp": "2018-05-07T12:56:47+00:00", "clientip": "172.21.0.1", "host": "localhost", "auth": "", "verb": "POST", "request": "/web/dataset/call_kw/web.planner/search_read", "httpversion": "HTTP/1.1", "response": "200", "bytes": "511", "time_request": "0.049", "time_backend_connect": "0.000", "time_backend_response": "0.049", "cache": "", "referrer": "http://localhost/web", "agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0" }
{ "timestamp": "2018-05-07T12:56:47+00:00", "clientip": "172.21.0.1", "host": "localhost", "auth": "", "verb": "GET", "request": "/web/static/lib/fontawesome/fonts/fontawesome-webfont.woff2?v=4.7.0", "httpversion": "HTTP/1.1", "response": "200", "bytes": "77160", "time_request": "0.036", "time_backend_connect": "0.001", "time_backend_response": "0.036", "cache": "MISS", "referrer": "http://localhost/web/content/323-3a25eea/web.assets_common.0.css", "agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0" }
```