### PR TITLE
[IMP] switch to alpine version of nginx

### DIFF
--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM nginx:alpine
 MAINTAINER Camptocamp
 
 ADD https://github.com/kelseyhightower/confd/releases/download/v0.11.0/confd-0.11.0-linux-amd64 /usr/local/bin/confd


### PR DESCRIPTION
As we are not doing any OS specific modifications for this image, alpine should work just fine.
Cuts the size of a built image from 128mb to just over 35mb.