### PR TITLE
Fix docker-entrypoint for alpine usage

### DIFF
--- a/9.0/docker-entrypoint.sh
+++ b/9.0/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
As the Bash shell is not installed by default on Alpine linux starting
the container fails.
Switching to Bourne shell fixes the problem.