### PR TITLE
Remove forwarding of If-None-Match

### DIFF
--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -136,11 +136,6 @@ http {
       proxy_cache_bypass $http_cache_control;
       add_header X-Cache-Status $upstream_cache_status;
 
-      # Forward If-None-Match (which contains the ETag), so Odoo can decide
-      # to return a 304 instead of the content. Nginx would have returned a 304
-      # anyway, but we spare some traffic between odoo and nginx.
-      proxy_set_header If-None-Match $http_if_none_match; 
-
       # there is no inheritance of proxy_set_header, as soon as we define one at a level,
       # we need to redefine all
       include /etc/nginx/proxy_headers.conf;

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fix empty responses sent by nginx which caches a 304 response with 0 bytes
+  from the backend instead of the last 200 response.
+
 ## 1.4.0
 
 * Output the following log keys with numeric values: response, bytes,


### PR DESCRIPTION
When we forward the header, Odoo will (legitimately) return 304
responses without content, which will get cached by nginx as such.
Opening odoo from a fresh browser (with no prior files cached on disk)
will receive a 304 with no content.

There may be a way exclude this behavior from the cache, but the most
effective and safe change is to remove the header when forwarding to
odoo. Odoo will always have to read and return the whole content and
will have no possibility to return a 304 based on the If-None-Match
Etag, but this is the responsibility of nginx.