### PR TITLE
feat: add nginx longpolling port config

### DIFF
--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -85,7 +85,12 @@ http {
 
   # List of application servers
   {{ $odoo_host := getenv "NGX_ODOO_HOST" }}
-
+  # get port for longpolling
+  {{ if getenv "NGX_ODOO_LONGPOLLING_PORT" }}
+    {{ $odoo_longpolling_port :=  getenv "NGX_ODOO_LONGPOLLING_PORT" }}
+  {{ else }}
+    {{ $odoo_longpolling_port := 8072 }}
+  {{ end }}
   # Configuration for the server
   server {
     listen 80 default;
@@ -129,9 +134,9 @@ http {
    {{ end }}
    {{ end }}
 
-    location /longpolling/im/poll { proxy_pass http://{{ $odoo_host }}:8072; }
-    location /longpolling/poll { proxy_pass http://{{ $odoo_host }}:8072; }
-    location /websocket { proxy_pass http://{{ $odoo_host }}:8072; }
+    location /longpolling/im/poll { proxy_pass http://{{ $odoo_host }}:{{ $odoo_longpolling_port }}; }
+    location /longpolling/poll { proxy_pass http://{{ $odoo_host }}:{{ $odoo_longpolling_port }}; }
+    location /websocket { proxy_pass http://{{ $odoo_host }}:{{ $odoo_longpolling_port }}; }
 
     location /monitoring/status {
       proxy_pass http://{{ $odoo_host }}:8069;


### PR DESCRIPTION
* Purpose
In order to be able to start odoo in thread mode, not in worker.
we should redirect longpolling to 8069 port