### PR TITLE
allow setting cookies to Secure

### DIFF
--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -108,6 +108,9 @@ http {
       proxy_buffer_size 64k;
       proxy_busy_buffers_size 64k;
       proxy_intercept_errors on;
+      {{ if getenv "NGX_ODOO_SECURE_COOKIES" }}
+      proxy_cookie_path / "/; Secure";
+      {{end}}
     }
    {{ if getenv "NGX_ODOO_EXTRA_LOCATION" }}
     {{ $odoo_extra_location := getenv "NGX_ODOO_EXTRA_LOCATION" }}

--- a/README.md
+++ b/README.md
@@ -54,3 +54,8 @@ set the result in the variable 'NGX_HTPASSWD' ex:
 ```
 vrenaville:$apr1$lDdea9Jt$DAJQG0W1s4JEuuVQQxiur.
 ```
+
+### Secure cookies
+
+If you want all cookies to be have the Secure attribute, then you can set the
+environment variable NGX_ODOO_SECURE_COOKIES to 1.


### PR DESCRIPTION
setting the environment variable NGX_ODOO_SECURE_COOKIES will let nginx set the Secure flag on cookies