### PR TITLE
[FIX] shorter HSTS timeout

### DIFF
--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -93,7 +93,7 @@ http {
 
     client_max_body_size 1G;
 
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Strict-Transport-Security "max-age=600; includeSubDomains" always;
 
     access_log /var/log/nginx/access.log json_combined;
 
@@ -125,7 +125,7 @@ http {
       auth_basic_user_file /etc/nginx/htpasswd;
       {{ end }}
       add_header X-Static no;
-      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+      add_header Strict-Transport-Security "max-age=600; includeSubDomains" always;
       proxy_buffering off;
       proxy_buffer_size 64k;
       proxy_busy_buffers_size 64k;
@@ -173,7 +173,7 @@ http {
 
       proxy_cache_bypass $http_cache_control;
       add_header X-Cache-Status $upstream_cache_status;
-      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+      add_header Strict-Transport-Security "max-age=600; includeSubDomains" always;
       # there is no inheritance of proxy_set_header, as soon as we define one at a level,
       # we need to redefine all
       include /etc/nginx/proxy_headers.conf;


### PR DESCRIPTION
Until we have a stable setup for this, set the HSTS header with a max-age of 10min instead of 1y so we can test things