### PR TITLE
Disables the byte-range for /documents/pdf_content

### DIFF
--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -144,6 +144,12 @@ http {
       log_not_found off;
     }
 
+    location /documents/pdf_content {
+      proxy_pass http://{{ $odoo_host }}:8069;
+      max_ranges 0;
+      proxy_force_ranges on;          
+    }
+
     location ~* /[^/]+/static/ {
       try_files =404 @cached;
     }


### PR DESCRIPTION

We get the following traceback when trying to access documents on futurplus 16.0:

![image](https://github.com/camptocamp/docker-odoo-nginx/assets/67733397/d54bb7d4-b84f-4515-b357-494cc66f729d)

The concerned endpoint is `/documents/pdf_content` where the library pdfjs is used.

We have seen that byte-range `[begin,end]` is not properly  calculated  in pdfjs:
futurplus_odoo_v16/odoo/src/addons/web/static/lib/pdfjs/build/pdf.js

```
var PDFFetchStreamRangeReader =
/*#__PURE__*/
function () {
  function PDFFetchStreamRangeReader(stream, begin, end) {
    var _this2 = this;

    _classCallCheck(this, PDFFetchStreamRangeReader);

    this._stream = stream;
    this._reader = null;
    this._loaded = 0;
    var source = stream.source;
    this._withCredentials = source.withCredentials || false;
    this._readCapability = (0, _util.createPromiseCapability)();
    this._isStreamingSupported = !source.disableStream;

    if (typeof AbortController !== 'undefined') {
      this._abortController = new AbortController();
    }

    this._headers = new Headers();

    for (var property in this._stream.httpHeaders) {
      var value = this._stream.httpHeaders[property];

      if (typeof value === 'undefined') {
        continue;
      }

      this._headers.append(property, value);
    }
   
    /* BYTE-RANGE NOT PROPERLY CALCULATED */
    this._headers.append('Range', "bytes=".concat(begin, "-").concat(end - 1));

    var url = source.url;
    fetch(url, createFetchOptions(this._headers, this._withCredentials, this._abortController)).then(function (response) {
      if (!(0, _network_utils.validateResponseStatus)(response.status)) {
        throw (0, _network_utils.createResponseStatusError)(response.status, url);
      }

      _this2._readCapability.resolve();

      _this2._reader = response.body.getReader();
    });
    this.onProgress = null;
  }

```
Desactivate byte-range on the endpoint  `/documents/pdf_content` prevents the error.
`max_ranges 0;`  


