### PR TITLE
[FIX] raise proxy_buffers and proxy_buffer_size

### DIFF
--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -78,8 +78,8 @@ http {
   proxy_send_timeout      90;
   proxy_read_timeout      90;
 
-  proxy_buffers           32 4k;
-  proxy_buffer_size       1k;
+  proxy_buffers           32 8k;
+  proxy_buffer_size       4k;
   proxy_busy_buffers_size 8k;
   proxy_max_temp_file_size  2048m;
   proxy_temp_file_write_size  64k;


### PR DESCRIPTION
On Odoo 17 there has been a change in the hearders for the PDF viewer, which cause a larger header to be sent by Odoo on the response the the HTTP request for a document preview.

This larger header causes an error in Nginx because the value of is too small to hold it.

We raise that value from 1k to 4k.

We also raise the value of proxy_buffers: the memory used by nginx is well inside the limits of the pod in k8s so we can get a little bit more ease in there.

closes: BGIS-1374