### PR TITLE
make nginx X-Forwarded-For work properly

### DIFF
--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -119,6 +119,10 @@ http {
       proxy_cookie_path / "/; Secure";
       {{end}}
 
+      set_real_ip_from 127.0.0.0/24;
+      real_ip_header X-Forwarded-For;
+      real_ip_recursive on;
+
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;

--- a/9.0/templates/nginx.conf.tmpl
+++ b/9.0/templates/nginx.conf.tmpl
@@ -118,6 +118,11 @@ http {
       {{ if getenv "NGX_ODOO_SECURE_COOKIES" }}
       proxy_cookie_path / "/; Secure";
       {{end}}
+
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Real-IP $remote_addr;
     }
    {{ if getenv "NGX_ODOO_EXTRA_LOCATION" }}
     {{ $odoo_extra_location := getenv "NGX_ODOO_EXTRA_LOCATION" }}
@@ -148,10 +153,6 @@ http {
         proxy_pass http://{{ $odoo_host }}:{{ $odoo_longpolling_port }};
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Real-IP $remote_addr;
     }
 
     location /monitoring/status {


### PR DESCRIPTION
Actuellement, la config nginx n'utilise pas correctement les headers permettant d'identifier l'IP source du client.
Ceci empêche un audit de la provenance des connections, tant au niveau de Nginx que de Werkzeug.

La ligne 122 est propre au setup de QoQa utilisant Istio-Proxy. Elle peut être dupliquée pour tenir compte des différents autres setups dans lequel cette image est utilisée (probablement 10.x.y.z, 172.16.x.y, etc), comme dans l'exemple de la doc: https://nginx.org/en/docs/http/ngx_http_realip_module.html

Quoi qu'il en soit, ceci ne casse rien qui ne soit pas déjà cassé, yc le scénario où nginx est directement exposé au client, sans proxy entre deux.

Modif testée à la main et validée sur l'infra QoQa d'intégration.